### PR TITLE
fix: rename clawdbotPlugin to openclawPlugin in all sub-flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # nix-steipete-tools
 
-> Core tools for clawdbot. Batteries included. Always fresh.
+> Core tools for openclaw. Batteries included. Always fresh.
 
-Nix packaging for [Peter Steinberger's](https://github.com/steipete) tools, with per-tool clawdbot plugins. Part of the [nix-clawdbot](https://github.com/clawdbot/nix-clawdbot) ecosystem.
+Nix packaging for [Peter Steinberger's](https://github.com/steipete) tools, with per-tool openclaw plugins. Part of the [nix-openclaw](https://github.com/openclaw/nix-openclaw) ecosystem.
 
 Darwin/aarch64 plus Linux (x86_64/aarch64) for tools that ship Linux builds.
 On Linux, `summarize` is built from source (Node 22 + pnpm) since upstream only ships a macOS Bun binary.
 
 ## Why this exists
 
-These tools are essential for a capable clawdbot instance - screen capture, camera access, TTS, messaging. Packaging them as Nix flakes with clawdbot plugin metadata means:
+These tools are essential for a capable openclaw instance - screen capture, camera access, TTS, messaging. Packaging them as Nix flakes with openclaw plugin metadata means:
 
 - **Reproducible**: Pinned versions, no Homebrew drift
 - **Declarative**: Add a plugin, `home-manager switch`, done
@@ -31,15 +31,15 @@ These tools are essential for a capable clawdbot instance - screen capture, came
 | [**imsg**](https://github.com/steipete/imsg) | iMessage/SMS CLI |
 | [**oracle**](https://github.com/steipete/oracle) | Bundle prompts + files for AI queries |
 
-## Usage (as clawdbot plugins)
+## Usage (as openclaw plugins)
 
-Each tool is a subflake under `tools/<tool>/` exporting `clawdbotPlugin`. Point your nix-clawdbot config at the tool you want:
+Each tool is a subflake under `tools/<tool>/` exporting `openclawPlugin`. Point your nix-openclaw config at the tool you want:
 
 ```nix
-programs.clawdbot.plugins = [
-  { source = "github:clawdbot/nix-steipete-tools?dir=tools/camsnap"; }
-  { source = "github:clawdbot/nix-steipete-tools?dir=tools/peekaboo"; }
-  { source = "github:clawdbot/nix-steipete-tools?dir=tools/summarize"; }
+programs.openclaw.plugins = [
+  { source = "github:openclaw/nix-steipete-tools?dir=tools/camsnap"; }
+  { source = "github:openclaw/nix-steipete-tools?dir=tools/peekaboo"; }
+  { source = "github:openclaw/nix-steipete-tools?dir=tools/summarize"; }
 ];
 ```
 
@@ -53,7 +53,7 @@ Each plugin bundles:
 If you just want the binaries without the plugin wrapper:
 
 ```nix
-inputs.nix-steipete-tools.url = "github:clawdbot/nix-steipete-tools";
+inputs.nix-steipete-tools.url = "github:openclaw/nix-steipete-tools";
 
 # Then use:
 inputs.nix-steipete-tools.packages.aarch64-darwin.camsnap
@@ -68,7 +68,7 @@ inputs.nix-steipete-tools.packages.x86_64-linux.summarize
 
 ## Skills syncing
 
-Skills are vendored from [clawdbot/clawdbot](https://github.com/clawdbot/clawdbot) main branch. No pinning - we track latest.
+Skills are vendored from [openclaw/openclaw](https://github.com/openclaw/openclaw) main branch. No pinning - we track latest.
 
 ```bash
 go run ./cmd/sync-skills
@@ -90,7 +90,7 @@ Fetches latest release versions/URLs/hashes and updates the Nix expressions. Ora
 
 | Workflow | Schedule | What it does |
 |----------|----------|--------------|
-| **sync-skills** | Every 30 min | Pulls latest skills from clawdbot main |
+| **sync-skills** | Every 30 min | Pulls latest skills from openclaw main |
 | **update-tools** | Every 10 min | Checks for new tool releases |
 | **Garnix** | On push | Builds all packages via `checks.*` (darwin + linux) |
 

--- a/tools/bird/flake.nix
+++ b/tools/bird/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: bird";
+  description = "openclaw plugin: bird";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if bird == null then {} else { bird = bird; };
 
-      clawdbotPlugin = if bird == null then null else {
+      openclawPlugin = if bird == null then null else {
         name = "bird";
         skills = [ ./skills/bird ];
         packages = [ bird ];

--- a/tools/camsnap/flake.nix
+++ b/tools/camsnap/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: camsnap";
+  description = "openclaw plugin: camsnap";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if camsnap == null then {} else { camsnap = camsnap; };
 
-      clawdbotPlugin = if camsnap == null then null else {
+      openclawPlugin = if camsnap == null then null else {
         name = "camsnap";
         skills = [ ./skills/camsnap ];
         packages = [ camsnap ];

--- a/tools/gogcli/flake.nix
+++ b/tools/gogcli/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: gogcli";
+  description = "openclaw plugin: gogcli";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if gogcli == null then {} else { gogcli = gogcli; };
 
-      clawdbotPlugin = if gogcli == null then null else {
+      openclawPlugin = if gogcli == null then null else {
         name = "gogcli";
         skills = [ ./skills/gog ];
         packages = [ gogcli ];

--- a/tools/imsg/flake.nix
+++ b/tools/imsg/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: imsg";
+  description = "openclaw plugin: imsg";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if imsg == null then {} else { imsg = imsg; };
 
-      clawdbotPlugin = if imsg == null then null else {
+      openclawPlugin = if imsg == null then null else {
         name = "imsg";
         skills = [ ./skills/imsg ];
         packages = [ imsg ];

--- a/tools/oracle/flake.nix
+++ b/tools/oracle/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: oracle";
+  description = "openclaw plugin: oracle";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if oracle == null then {} else { oracle = oracle; };
 
-      clawdbotPlugin = if oracle == null then null else {
+      openclawPlugin = if oracle == null then null else {
         name = "oracle";
         skills = [ ./skills/oracle ];
         packages = [ oracle ];

--- a/tools/peekaboo/flake.nix
+++ b/tools/peekaboo/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: peekaboo";
+  description = "openclaw plugin: peekaboo";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if peekaboo == null then {} else { peekaboo = peekaboo; };
 
-      clawdbotPlugin = if peekaboo == null then null else {
+      openclawPlugin = if peekaboo == null then null else {
         name = "peekaboo";
         skills = [ ./skills/peekaboo ];
         packages = [ peekaboo ];

--- a/tools/poltergeist/flake.nix
+++ b/tools/poltergeist/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: poltergeist";
+  description = "openclaw plugin: poltergeist";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if poltergeist == null then {} else { poltergeist = poltergeist; };
 
-      clawdbotPlugin = if poltergeist == null then null else {
+      openclawPlugin = if poltergeist == null then null else {
         name = "poltergeist";
         skills = [ ./skills/poltergeist ];
         packages = [ poltergeist ];

--- a/tools/sag/flake.nix
+++ b/tools/sag/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: sag";
+  description = "openclaw plugin: sag";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if sag == null then {} else { sag = sag; };
 
-      clawdbotPlugin = if sag == null then null else {
+      openclawPlugin = if sag == null then null else {
         name = "sag";
         skills = [ ./skills/sag ];
         packages = [ sag ];

--- a/tools/sonoscli/flake.nix
+++ b/tools/sonoscli/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: sonoscli";
+  description = "openclaw plugin: sonoscli";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if sonoscli == null then {} else { sonoscli = sonoscli; };
 
-      clawdbotPlugin = if sonoscli == null then null else {
+      openclawPlugin = if sonoscli == null then null else {
         name = "sonoscli";
         skills = [ ./skills/sonoscli ];
         packages = [ sonoscli ];

--- a/tools/summarize/flake.nix
+++ b/tools/summarize/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "clawdbot plugin: summarize";
+  description = "openclaw plugin: summarize";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=16c7794d0a28b5a37904d55bcca36003b9109aaa&narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D";
@@ -14,7 +14,7 @@
     in {
       packages.${system} = if summarize == null then {} else { summarize = summarize; };
 
-      clawdbotPlugin = if summarize == null then null else {
+      openclawPlugin = if summarize == null then null else {
         name = "summarize";
         skills = [ ./skills/summarize ];
         packages = [ summarize ];


### PR DESCRIPTION
Rename the plugin export attribute from clawdbotPlugin to openclawPlugin across all 10 tool sub-flakes and update README references to match the openclaw rebrand.

Without this, nix-openclaw's Home Manager module fails with: "openclawPlugin missing in nix-steipete-tools"

Warning: This is my first serious dive into Nix. If this is incorrect, no worries, I'm just trying to fix an issue I ran into this morning.