### PR TITLE
fix: remove .pnpm-workspace-state-v1.json from tool outputs

### DIFF
--- a/nix/pkgs/oracle.nix
+++ b/nix/pkgs/oracle.nix
@@ -112,6 +112,7 @@ PY
     runHook preInstall
     mkdir -p "$out/libexec" "$out/bin"
     cp -r dist package.json vendor assets-oracle-icon.png node_modules "$out/libexec/"
+    find "$out/libexec/node_modules" -name ".pnpm-workspace-state-v1.json" -delete
     chmod 0755 "$out/libexec/dist/bin/oracle-cli.js" "$out/libexec/dist/bin/oracle-mcp.js"
     ln -s "$out/libexec/dist/bin/oracle-cli.js" "$out/bin/oracle"
     ln -s "$out/libexec/dist/bin/oracle-mcp.js" "$out/bin/oracle-mcp"

--- a/nix/pkgs/summarize.nix
+++ b/nix/pkgs/summarize.nix
@@ -120,6 +120,7 @@ if stdenv.isLinux then
       runHook preInstall
       mkdir -p "$out/libexec" "$out/libexec/packages" "$out/libexec/apps" "$out/bin"
       cp -r dist node_modules "$out/libexec/"
+      find "$out/libexec/node_modules" -name ".pnpm-workspace-state-v1.json" -delete
       cp -r packages/core "$out/libexec/packages/"
       cp -r apps/chrome-extension "$out/libexec/apps/"
       chmod 0755 "$out/libexec/dist/cli.js"


### PR DESCRIPTION
## Summary
- Remove `.pnpm-workspace-state-v1.json` from `$out/libexec/node_modules/` in both `oracle.nix` and `summarize.nix` install phases
- This pnpm build artifact is not needed at runtime and causes `pkgs.buildEnv` collisions when multiple tools are installed together

Fixes #2

## Test plan
- [ ] Build oracle and summarize individually and verify they still work
- [ ] Build both together in a home-manager environment and confirm no `buildEnv` conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)