### PR TITLE
Add flake.lock for tools/summarize sub-flake

### DIFF
--- a/tools/summarize/flake.lock
+++ b/tools/summarize/flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "type": "github"
+      },
+      "original": {
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "root": "root_2"
+      }
+    },
+    "root_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1769797395,
+        "narHash": "sha256-QkPl/Rgk9DXgaVNhjvHHHjy5e81j+MzcVOouZRdUTLA=",
+        "owner": "openclaw",
+        "repo": "nix-steipete-tools",
+        "rev": "dbf0a31a57407d9140e32357ea8d0215bd9feed9",
+        "type": "github"
+      },
+      "original": {
+        "narHash": "sha256-QkPl/Rgk9DXgaVNhjvHHHjy5e81j+MzcVOouZRdUTLA=",
+        "owner": "openclaw",
+        "repo": "nix-steipete-tools",
+        "rev": "dbf0a31a57407d9140e32357ea8d0215bd9feed9",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
## Summary
- Adds a committed `flake.lock` for the `tools/summarize` sub-flake
- Without this, any downstream flake that evaluates this sub-flake produces a `not writing modified lock file` warning on every invocation (e.g. `nix flake check`), since Nix resolves inputs at eval time but cannot persist the lock to a read-only store path

🤖 Generated with [Claude Code](https://claude.com/claude-code)