### PR TITLE
Add RepoBar and Trimmy app packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Homebrew configuration, not in these pure Nix package/module definitions.
 | [**sag**](https://github.com/steipete/sag) | Command-line ElevenLabs TTS with mac-style flags |
 | [**imsg**](https://github.com/steipete/imsg) | iMessage/SMS CLI |
 | [**CodexBar**](https://github.com/steipete/CodexBar) | macOS menu bar app for Codex, Claude, and other provider usage |
+| [**RepoBar**](https://github.com/steipete/RepoBar) | macOS menu bar app for GitHub CI, PRs, and releases |
+| [**Trimmy**](https://github.com/steipete/Trimmy) | macOS menu bar app for flattening multi-line shell snippets |
 
 ## Usage (as openclaw plugins)
 
@@ -78,6 +80,8 @@ inputs.nix-steipete-tools.packages.aarch64-darwin.discrawl
 inputs.nix-steipete-tools.packages.aarch64-darwin.peekaboo
 inputs.nix-steipete-tools.packages.aarch64-darwin.wacrawl
 inputs.nix-steipete-tools.packages.aarch64-darwin.codexbar-app
+inputs.nix-steipete-tools.packages.aarch64-darwin.repobar-app
+inputs.nix-steipete-tools.packages.aarch64-darwin.trimmy-app
 # etc.
 
 # Linux examples:
@@ -91,23 +95,42 @@ inputs.nix-steipete-tools.packages.x86_64-linux.wacrawl
 ### Home Manager modules
 
 Some packages also ship Home Manager modules so they can be enabled directly
-without hand-writing install and launchd wiring. For CodexBar:
+without hand-writing install and launchd wiring. For CodexBar, RepoBar, and
+Trimmy:
 
 ```nix
 {
-  imports = [ inputs.nix-steipete-tools.homeManagerModules.codexbar ];
+  imports = [
+    inputs.nix-steipete-tools.homeManagerModules.codexbar
+    inputs.nix-steipete-tools.homeManagerModules.repobar
+    inputs.nix-steipete-tools.homeManagerModules.trimmy
+  ];
 
   programs.codexbar.enable = true;
+  programs.repobar.enable = true;
+  programs.trimmy.enable = true;
 }
 ```
 
-That adds the CodexBar app package to `home.packages`. Home Manager can then
-expose the app bundle through its Darwin app targets. If you want Home Manager
-to own startup too, enable the launchd agent explicitly:
+That adds the app packages to `home.packages`. Home Manager can then expose the
+app bundles through its Darwin app targets. If you want Home Manager to own
+startup too, enable each launchd agent explicitly:
 
 ```nix
 {
   programs.codexbar = {
+    enable = true;
+    launchd.enable = true;
+    launchd.keepAlive = false;
+  };
+
+  programs.repobar = {
+    enable = true;
+    launchd.enable = true;
+    launchd.keepAlive = false;
+  };
+
+  programs.trimmy = {
     enable = true;
     launchd.enable = true;
     launchd.keepAlive = false;
@@ -121,6 +144,8 @@ If you only want the raw app package, use the package output directly:
 
 ```nix
 inputs.nix-steipete-tools.packages.aarch64-darwin.codexbar-app
+inputs.nix-steipete-tools.packages.aarch64-darwin.repobar-app
+inputs.nix-steipete-tools.packages.aarch64-darwin.trimmy-app
 ```
 
 ## Skills syncing

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,8 @@
         sag = [ "aarch64-darwin" "x86_64-linux" ];
         imsg = [ "aarch64-darwin" ];
         codexbar-app = [ "aarch64-darwin" ];
+        repobar-app = [ "aarch64-darwin" ];
+        trimmy-app = [ "aarch64-darwin" ];
       };
     in {
       packages = forAllSystems (system:
@@ -70,10 +72,18 @@
           // (lib.optionalAttrs (supports "codexbar-app") {
             codexbar-app = pkgs.callPackage ./nix/pkgs/codexbar-app.nix {};
           })
+          // (lib.optionalAttrs (supports "repobar-app") {
+            repobar-app = pkgs.callPackage ./nix/pkgs/repobar-app.nix {};
+          })
+          // (lib.optionalAttrs (supports "trimmy-app") {
+            trimmy-app = pkgs.callPackage ./nix/pkgs/trimmy-app.nix {};
+          })
       );
 
       homeManagerModules = {
         codexbar = import ./nix/modules/home-manager/codexbar.nix { inherit self; };
+        repobar = import ./nix/modules/home-manager/repobar.nix { inherit self; };
+        trimmy = import ./nix/modules/home-manager/trimmy.nix { inherit self; };
         default = self.homeManagerModules.codexbar;
       };
 

--- a/nix/modules/home-manager/repobar.nix
+++ b/nix/modules/home-manager/repobar.nix
@@ -1,0 +1,88 @@
+{ self }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkEnableOption mkIf mkOption types;
+  cfg = config.programs.repobar;
+  system = pkgs.stdenv.hostPlatform.system;
+  defaultPackage =
+    if self.packages ? ${system} && self.packages.${system} ? repobar-app then
+      self.packages.${system}.repobar-app
+    else
+      null;
+in
+{
+  options.programs.repobar = {
+    enable = mkEnableOption "RepoBar macOS menu bar app";
+
+    package = mkOption {
+      type = types.nullOr types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "inputs.nix-steipete-tools.packages.\${pkgs.system}.repobar-app";
+      description = "RepoBar app package.";
+    };
+
+    launchd = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Configure a launchd agent to manage the RepoBar process.
+
+          RepoBar can also manage launch-at-login from inside the app. Enable this
+          option when you want Home Manager and launchd to own startup instead.
+        '';
+      };
+
+      keepAlive = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether launchd should restart RepoBar after it exits.";
+      };
+
+      environmentVariables = mkOption {
+        type = types.attrsOf types.str;
+        default = {
+          PATH = "${config.home.profileDirectory}/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+        };
+        defaultText = lib.literalExpression ''
+          {
+            PATH = "\${config.home.profileDirectory}/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+          }
+        '';
+        description = "Environment variables passed to the RepoBar launchd agent.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.repobar" pkgs lib.platforms.darwin)
+      {
+        assertion = cfg.package != null;
+        message = "programs.repobar.package must be set on this platform.";
+      }
+      {
+        assertion = !cfg.launchd.enable || config.launchd.enable;
+        message = "programs.repobar.launchd.enable requires launchd.enable.";
+      }
+    ];
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    launchd.agents.repobar = mkIf cfg.launchd.enable {
+      enable = true;
+      config = {
+        ProgramArguments = [ "${cfg.package}/Applications/RepoBar.app/Contents/MacOS/RepoBar" ];
+        ProcessType = "Interactive";
+        RunAtLoad = true;
+        KeepAlive = cfg.launchd.keepAlive;
+        EnvironmentVariables = cfg.launchd.environmentVariables;
+      };
+    };
+  };
+}

--- a/nix/modules/home-manager/trimmy.nix
+++ b/nix/modules/home-manager/trimmy.nix
@@ -1,0 +1,88 @@
+{ self }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkEnableOption mkIf mkOption types;
+  cfg = config.programs.trimmy;
+  system = pkgs.stdenv.hostPlatform.system;
+  defaultPackage =
+    if self.packages ? ${system} && self.packages.${system} ? trimmy-app then
+      self.packages.${system}.trimmy-app
+    else
+      null;
+in
+{
+  options.programs.trimmy = {
+    enable = mkEnableOption "Trimmy macOS menu bar app";
+
+    package = mkOption {
+      type = types.nullOr types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "inputs.nix-steipete-tools.packages.\${pkgs.system}.trimmy-app";
+      description = "Trimmy app package.";
+    };
+
+    launchd = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Configure a launchd agent to manage the Trimmy process.
+
+          Trimmy can also manage launch-at-login from inside the app. Enable this
+          option when you want Home Manager and launchd to own startup instead.
+        '';
+      };
+
+      keepAlive = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether launchd should restart Trimmy after it exits.";
+      };
+
+      environmentVariables = mkOption {
+        type = types.attrsOf types.str;
+        default = {
+          PATH = "${config.home.profileDirectory}/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+        };
+        defaultText = lib.literalExpression ''
+          {
+            PATH = "\${config.home.profileDirectory}/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+          }
+        '';
+        description = "Environment variables passed to the Trimmy launchd agent.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.trimmy" pkgs lib.platforms.darwin)
+      {
+        assertion = cfg.package != null;
+        message = "programs.trimmy.package must be set on this platform.";
+      }
+      {
+        assertion = !cfg.launchd.enable || config.launchd.enable;
+        message = "programs.trimmy.launchd.enable requires launchd.enable.";
+      }
+    ];
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    launchd.agents.trimmy = mkIf cfg.launchd.enable {
+      enable = true;
+      config = {
+        ProgramArguments = [ "${cfg.package}/Applications/Trimmy.app/Contents/MacOS/Trimmy" ];
+        ProcessType = "Interactive";
+        RunAtLoad = true;
+        KeepAlive = cfg.launchd.keepAlive;
+        EnvironmentVariables = cfg.launchd.environmentVariables;
+      };
+    };
+  };
+}

--- a/nix/pkgs/repobar-app.nix
+++ b/nix/pkgs/repobar-app.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "repobar-app";
+  version = "0.2.0";
+
+  src = fetchzip {
+    url = "https://github.com/steipete/RepoBar/releases/download/v0.2.0/RepoBar-0.2.0.zip";
+    hash = "sha256-/Sp0DjbiCsmAx+Oh6A3t02TDLiPKUkHkYo8DPgfF1dI=";
+    stripRoot = false;
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/Applications"
+    app_path="$src/RepoBar.app"
+    if [ ! -d "$app_path" ]; then
+      echo "RepoBar.app not found in $src" >&2
+      exit 1
+    fi
+    cp -R "$app_path" "$out/Applications/RepoBar.app"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "RepoBar macOS menu bar app bundle";
+    homepage = "https://github.com/steipete/RepoBar";
+    license = licenses.mit;
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/nix/pkgs/trimmy-app.nix
+++ b/nix/pkgs/trimmy-app.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "trimmy-app";
+  version = "0.8.0";
+
+  src = fetchzip {
+    url = "https://github.com/steipete/Trimmy/releases/download/v0.8.0/Trimmy-0.8.0.zip";
+    hash = "sha256-1uMz6mznUN1UMkPRgodVM3LtuGlsG8kWCyehRZ9GW8s=";
+    stripRoot = false;
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/Applications"
+    app_path="$src/Trimmy.app"
+    if [ ! -d "$app_path" ]; then
+      echo "Trimmy.app not found in $src" >&2
+      exit 1
+    fi
+    cp -R "$app_path" "$out/Applications/Trimmy.app"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Trimmy macOS menu bar app bundle";
+    homepage = "https://github.com/steipete/Trimmy";
+    license = licenses.mit;
+    platforms = [ "aarch64-darwin" ];
+  };
+}


### PR DESCRIPTION
Adds two more Swift macOS app packages:

- RepoBar.app with a Home Manager module
- Trimmy.app with a Home Manager module

This follows the same standard pattern as the CodexBar app package/module from #13: package the app bundle, expose it from the flake, and provide an optional launchd-backed Home Manager module.

No Go updater changes are needed here since these are pinned app bundle packages rather than updater-managed CLI release entries.

Verification:
- nix build --no-link --print-out-paths .#repobar-app .#trimmy-app
- nix flake show --no-write-lock-file --all-systems