### PR TITLE
fix(update-tools): match peekaboo arm64 asset name

### DIFF
--- a/cmd/update-tools/main.go
+++ b/cmd/update-tools/main.go
@@ -212,7 +212,7 @@ func main() {
 			Name: "peekaboo",
 			Repo: "steipete/peekaboo",
 			Assets: []AssetSpec{
-				{System: "aarch64-darwin", Regex: regexp.MustCompile(`peekaboo-macos-universal\.tar\.gz`)},
+				{System: "aarch64-darwin", Regex: regexp.MustCompile(`peekaboo-macos-(?:universal|arm64)\.tar\.gz`)},
 			},
 			NixFile: filepath.Join(repoRoot, "nix", "pkgs", "peekaboo.nix"),
 		},


### PR DESCRIPTION
## Summary
- Peekaboo `v3.0.0-beta4` renamed the macOS asset from `peekaboo-macos-universal.tar.gz` to `peekaboo-macos-arm64.tar.gz`.
- The `update-tools` regex still required `universal`, so every scheduled run fails with `no asset matched for peekaboo (aarch64-darwin)` (e.g. run [25143169327](https://github.com/openclaw/nix-steipete-tools/actions/runs/25143169327)).
- Widen the matcher to accept `universal|arm64` so updates resume without losing compatibility with older releases.

## Test plan
- [x] Verified the new regex matches both `peekaboo-macos-universal.tar.gz` and `peekaboo-macos-arm64.tar.gz`, and rejects unrelated assets.
- [ ] Re-run the `update-tools` workflow after merge to confirm it succeeds and bumps `nix/pkgs/peekaboo.nix` to the latest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)